### PR TITLE
Create BoardConfig.mk

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -23,7 +23,7 @@ TARGET_BOOTLOADER_BOARD_NAME := MSM8974
 
 # Kernel
 TARGET_KERNEL_SOURCE := kernel/samsung/ks01lte
-TARGET_KERNEL_CONFIG := cyanogenmod_ks01lte_defconfig
+TARGET_KERNEL_CONFIG := lineageos_ks01lte_defconfig	
 BOARD_MKBOOTIMG_ARGS := --ramdisk_offset 0x02000000 --tags_offset 0x01e00000
 BOARD_KERNEL_CMDLINE := console=null androidboot.hardware=qcom user_debug=31 msm_rtb.filter=0x3F androidboot.bootdevice=msm_sdcc.1
 BOARD_KERNEL_BASE := 0x00000000


### PR DESCRIPTION
Changed from 'cyanogenmod_ks01lte_defconfig' to 'lineageos_ks01lte_defconfig' because the first defconfig wasn't found in android_kernel_samsung_ks01lte arch/arm/configs.